### PR TITLE
Fix module export for Node

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,4 +1,4 @@
-export default async function handler(req, res) {
+module.exports = async function handler(req, res) {
   try {
     if (req.method === 'GET') {
       const VERIFY_TOKEN = 'equibox-token';
@@ -21,4 +21,4 @@ export default async function handler(req, res) {
     console.error('❌ Error en el webhook:', error);
     res.status(500).send('Error interno del servidor');
   }
-}
+};


### PR DESCRIPTION
## Summary
- use CommonJS export syntax in `api/webhook.js`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b5758910883318de8ecea11e43b77