### PR TITLE
Add Jest supertest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "webhook-whatsapp-equinox25",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/tests/webhook.test.js
+++ b/tests/webhook.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest');
+const express = require('express');
+const handler = require('../api/webhook');
+
+function createServer() {
+  const app = express();
+  app.use(express.json());
+  app.all('/api/webhook', (req, res) => handler(req, res));
+  return app;
+}
+
+describe('webhook handler', () => {
+  const app = createServer();
+
+  test('GET with correct verify token returns challenge', async () => {
+    const res = await request(app)
+      .get('/api/webhook')
+      .query({
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'equinox-token',
+        'hub.challenge': '12345',
+      });
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toBe('12345');
+  });
+
+  test('GET with invalid token returns 403', async () => {
+    const res = await request(app)
+      .get('/api/webhook')
+      .query({
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'wrong',
+        'hub.challenge': 'abc',
+      });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('POST request returns 200', async () => {
+    const res = await request(app)
+      .post('/api/webhook')
+      .send({ foo: 'bar' });
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest and Supertest
- configure Jest for Node
- add webhook endpoint tests

## Testing
- `npm install --save-dev jest supertest` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5b1bed988331a9a76b11fa75f64f