### PR TITLE
Configure webhook for Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.vercel/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # webhook-whatsapp-equinox25
+
+Este proyecto contiene una función serverless para gestionar el webhook de WhatsApp y está preparado para desplegarse en **Vercel**.
+
+## Desarrollo local
+
+1. Instala las dependencias (si las hubiera) y ejecuta el servidor de desarrollo:
+   ```bash
+   npm run dev
+   ```
+
+2. Configura la variable de entorno `VERIFY_TOKEN` con el valor que utilizarás para la verificación del webhook.
+
+## Despliegue en Vercel
+
+1. Crea un proyecto en Vercel y sube este repositorio.
+2. Define la variable de entorno `VERIFY_TOKEN` desde el panel de configuración de Vercel.
+3. Ejecuta `vercel --prod` para desplegar.

--- a/api/webhook.js
+++ b/api/webhook.js
@@ -1,7 +1,7 @@
 module.exports = async function handler(req, res) {
   try {
     if (req.method === 'GET') {
-      const VERIFY_TOKEN = 'equinox-token';
+      const VERIFY_TOKEN = process.env.VERIFY_TOKEN || 'equinox-token';
       const mode = req.query['hub.mode'];
       const token = req.query['hub.verify_token'];
       const challenge = req.query['hub.challenge'];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "webhook-whatsapp-equinox25",
+  "version": "1.0.0",
+  "license": "MIT",
+  "type": "commonjs",
+  "engines": {
+    "node": "18.x"
+  },
+  "scripts": {
+    "dev": "vercel dev"
+  }
+}


### PR DESCRIPTION
## Summary
- add example `.gitignore`
- use `VERIFY_TOKEN` from env for flexibility
- include `package.json` with `vercel dev` script
- document how to run locally and deploy to Vercel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b5d54dc78833185f2afa878e3adc1